### PR TITLE
Handle ignore class in semantic segmentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN conda install -y jupyter=1.0.*
 RUN conda clean -ya
 
 # RUN pip install rastervision==0.9.0rc1
-RUN pip install git+git://github.com/azavea/raster-vision.git@fac841e50c1bd29483fecd130cf78d1cc9738dc7
+RUN pip install git+git://github.com/azavea/raster-vision.git@d23cc18d805f1e0bce29c6595f113eff466a04f6
 RUN pip install ptvsd==4.2.*
 
 # See https://github.com/mapbox/rasterio/issues/1289

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,7 @@ RUN conda install -y -c conda-forge awscli=1.16.* boto3=1.9.*
 RUN conda install -y jupyter=1.0.*
 RUN conda clean -ya
 
-# RUN pip install rastervision==0.9.0rc1
-RUN pip install git+git://github.com/azavea/raster-vision.git@d23cc18d805f1e0bce29c6595f113eff466a04f6
+RUN pip install git+git://github.com/azavea/raster-vision.git@6bd3d1701d37763b3893b4b97ed1152e75b15f85
 RUN pip install ptvsd==4.2.*
 
 # See https://github.com/mapbox/rasterio/issues/1289

--- a/fastai_plugin/semantic_segmentation_backend.py
+++ b/fastai_plugin/semantic_segmentation_backend.py
@@ -226,7 +226,7 @@ class SemanticSegmentationBackend(Backend):
             TrackEpochCallback(learn),
             MySaveModelCallback(learn, every='epoch'),
             MyCSVLogger(learn, filename='log'),
-            ExportCallback(learn, model_path),
+            ExportCallback(learn, model_path, monitor='f_beta'),
             SyncCallback(train_dir, self.backend_opts.train_uri,
                          self.train_opts.sync_interval)
         ]

--- a/fastai_plugin/semantic_segmentation_backend.py
+++ b/fastai_plugin/semantic_segmentation_backend.py
@@ -235,8 +235,8 @@ class SemanticSegmentationBackend(Backend):
         num_epochs = self.train_opts.num_epochs
         if self.train_opts.one_cycle:
             if lr is None:
-                learn.lr_find(num_it=50)
-                learn.recorder.plot(suggestion=True)
+                learn.lr_find()
+                learn.recorder.plot(suggestion=True, return_fig=True)
                 lr = learn.recorder.min_grad_lr
                 print('lr_find() found lr: {}'.format(lr))
             learn.fit_one_cycle(num_epochs, lr, callbacks=callbacks)

--- a/fastai_plugin/semantic_segmentation_backend_config.py
+++ b/fastai_plugin/semantic_segmentation_backend_config.py
@@ -12,11 +12,13 @@ FASTAI_SEMANTIC_SEGMENTATION = 'FASTAI_SEMANTIC_SEGMENTATION'
 
 class TrainOptions():
     def __init__(self, batch_sz=None, weight_decay=None, lr=None,
+                 one_cycle=None,
                  num_epochs=None, model_arch=None, fp16=None,
                  sync_interval=None, debug=None):
         self.batch_sz = batch_sz
         self.weight_decay = weight_decay
         self.lr = lr
+        self.one_cycle = one_cycle
         self.num_epochs = num_epochs
         self.model_arch = model_arch
         self.fp16 = fp16
@@ -46,6 +48,7 @@ class SemanticSegmentationBackendConfigBuilder(SimpleBackendConfigBuilder):
             batch_sz=8,
             weight_decay=1e-2,
             lr=1e-4,
+            one_cycle=False,
             num_epochs=5,
             model_arch='resnet18',
             fp16=False,
@@ -54,6 +57,7 @@ class SemanticSegmentationBackendConfigBuilder(SimpleBackendConfigBuilder):
         b = deepcopy(self)
         b.train_opts = TrainOptions(
             batch_sz=batch_sz, weight_decay=weight_decay, lr=lr,
+            one_cycle=one_cycle,
             num_epochs=num_epochs, model_arch=model_arch, fp16=fp16,
             sync_interval=sync_interval, debug=debug)
         return b


### PR DESCRIPTION
This PR makes it so a class id of 0 (the ignore class) is handled sensibly for semantic segmentation. It also adds a `one_cycle` option for training, and improves model save and export functionality.