### PR TITLE
add option for using subset of training chips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN conda install -y jupyter=1.0.*
 RUN conda clean -ya
 
 # RUN pip install rastervision==0.9.0rc1
-RUN pip install git+git://github.com/azavea/raster-vision.git@fac841e50c1bd29483fecd130cf78d1cc9738dc7
+RUN pip install git+git://github.com/azavea/raster-vision.git@d23cc18d805f1e0bce29c6595f113eff466a04f6
 RUN pip install ptvsd==4.2.*
 
 # See https://github.com/mapbox/rasterio/issues/1289

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ RUN apt-get update && apt-get install -y software-properties-common python-softw
 RUN add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     apt-get install -y wget=1.* git=1:2.* python-protobuf=2.* python3-tk=3.* \
-                       gdal-bin=2.1.* \
+                       gdal-bin=2.2.* \
                        jq=1.5* \
                        build-essential libsqlite3-dev=3.11.* zlib1g-dev=1:1.2.* \
                        libopencv-dev=2.4.* python-opencv=2.4.* && \
     apt-get autoremove && apt-get autoclean && apt-get clean
 
 # Setup GDAL_DATA directory, rasterio needs it.
-ENV GDAL_DATA=/usr/share/gdal/2.1/
+ENV GDAL_DATA=/usr/share/gdal/2.2/
 
 RUN apt-get install -y unzip
 

--- a/examples/semantic_segmentation/potsdam.py
+++ b/examples/semantic_segmentation/potsdam.py
@@ -139,6 +139,22 @@ class PotsdamSemanticSegmentation(rv.ExperimentSet):
         }
         return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri,
                             test)
+    
+    def exp_half_train_data(self, raw_uri, processed_uri, root_uri, test=False):
+        # This can be removed, I just have it in here in order to easily test the 
+        # train proportion config parameter
+        exp_id = 'resnet18-half_train_data'
+        config = {
+            'batch_sz': 8,
+            'num_epochs': 5,
+            'debug': False,
+            'lr': 1e-4,
+            'sync_interval': 10,
+            'model_arch': 'resnet18',
+            'train_proportion': 0.5
+        }
+        return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri,
+                            test)
 
 
 if __name__ == '__main__':

--- a/examples/semantic_segmentation/potsdam.py
+++ b/examples/semantic_segmentation/potsdam.py
@@ -139,10 +139,9 @@ class PotsdamSemanticSegmentation(rv.ExperimentSet):
         }
         return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri,
                             test)
-    
-    def exp_half_train_data(self, raw_uri, processed_uri, root_uri, test=False):
-        # This can be removed, I just have it in here in order to easily test the 
-        # train proportion config parameter
+
+    # Example of experiment using half of the training chips
+    def exp_subset_half_train_data(self, raw_uri, processed_uri, root_uri, test=False):
         exp_id = 'resnet18-half_train_data'
         config = {
             'batch_sz': 8,
@@ -151,7 +150,22 @@ class PotsdamSemanticSegmentation(rv.ExperimentSet):
             'lr': 1e-4,
             'sync_interval': 10,
             'model_arch': 'resnet18',
-            'train_proportion': 0.5
+            'train_prop': 0.5
+        }
+        return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri,
+                            test)
+
+    # Example of experiment using exactlty 5,000 chips
+    def exp_subset_5k_chips(self, raw_uri, processed_uri, root_uri, test=False):
+        exp_id = 'resnet18-5k_train_chips'
+        config = {
+            'batch_sz': 8,
+            'num_epochs': 5,
+            'debug': False,
+            'lr': 1e-4,
+            'sync_interval': 10,
+            'model_arch': 'resnet18',
+            'train_count': 5000
         }
         return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri,
                             test)

--- a/fastai_plugin/semantic_segmentation_backend.py
+++ b/fastai_plugin/semantic_segmentation_backend.py
@@ -220,8 +220,6 @@ class SemanticSegmentationBackend(Backend):
             classes = ['nodata'] + classes
         num_workers = 0 if self.train_opts.debug else 4
         
-        import pdb
-        pdb.set_trace()
         if self.train_opts.train_proportion >= 1:
             train_img_dir = 'train-img'
         else:

--- a/fastai_plugin/semantic_segmentation_backend.py
+++ b/fastai_plugin/semantic_segmentation_backend.py
@@ -220,7 +220,9 @@ class SemanticSegmentationBackend(Backend):
             classes = ['nodata'] + classes
         num_workers = 0 if self.train_opts.debug else 4
         
-        if self.train_opts.train_proportion >= 1:
+        if self.train_opts.train_proportion > 1 or self.train_opts.train_proportion < 0:
+            raise Exception('Value for "train_proportion" must be between 0 and 1, got {}.'.format(self.train_opts.train_proportion)) 
+        if self.train_opts.train_proportion == 1:
             train_img_dir = 'train-img'
         else:
             train_img_dir = self.subset_training_data(chip_dir)

--- a/fastai_plugin/semantic_segmentation_backend.py
+++ b/fastai_plugin/semantic_segmentation_backend.py
@@ -183,7 +183,7 @@ class SemanticSegmentationBackend(Backend):
             sample_dir_uri = join(chip_dir, sample_dir)
             make_dir(sample_dir_uri)
             for s in sample_images:
-                upload_or_copy(join(all_uri, s), join(sample_dir, s))
+                upload_or_copy(join(all_uri, s), join(sample_dir_uri, s))
             return sample_dir
             
         for i in ('labels', 'img'):
@@ -220,6 +220,8 @@ class SemanticSegmentationBackend(Backend):
             classes = ['nodata'] + classes
         num_workers = 0 if self.train_opts.debug else 4
         
+        import pdb
+        pdb.set_trace()
         if self.train_opts.train_proportion >= 1:
             train_img_dir = 'train-img'
         else:
@@ -232,7 +234,7 @@ class SemanticSegmentationBackend(Backend):
                 .databunch(bs=self.train_opts.batch_sz,
                            num_workers=num_workers))
         print(data)
-
+    
         if self.train_opts.debug:
             make_debug_chips(data, class_map, tmp_dir, train_uri)
 

--- a/fastai_plugin/semantic_segmentation_backend.py
+++ b/fastai_plugin/semantic_segmentation_backend.py
@@ -158,9 +158,10 @@ class SemanticSegmentationBackend(Backend):
     def subset_training_data(self, chip_dir):
         """ Specify a subset of all the training chips that have been created
 
-        This creates uses the train_opts 'train_proportion' parameter to
-            subset a number (n) of the training chips. It creates two new 
-            directories 'train-{n}-img' and 'train-{n}-labels' with
+        This creates uses the train_opts 'train_count' or 'train_prop' parameter to
+            subset a number (n) of the training chips. The function prioritizes
+            'train_count' and falls back to 'train_prop' if 'train_count' is not set. 
+            It creates two new directories 'train-{n}-img' and 'train-{n}-labels' with
             subsets of the chips that the dataloader can read from.
 
         Args:
@@ -168,13 +169,30 @@ class SemanticSegmentationBackend(Backend):
 
         Returns:
             (str) name of the train subset image directory (e.g. 'train-{n}-img')
-        """        
-        random.seed(100)
-        prop = self.train_opts.train_proportion
+        """
+        
 
         all_train_uri = join(chip_dir, 'train-img')
-        all_train = os.listdir(all_train_uri)
-        sample_size = round(prop * len(all_train))
+        all_train = list(filter(lambda x: x.endswith(
+            '.png'), os.listdir(all_train_uri)))
+        all_train.sort()
+
+        count = self.train_opts.train_count
+        if count:
+            if count > len(all_train):
+                raise Exception('Value for "train_count" ({}) must be less '
+                                'than or equal to the total number of chips ({}) '
+                                'in the train set.'.format(count, len(all_train)))
+            sample_size = int(count)
+        else:
+            prop = self.train_opts.train_prop
+            if prop > 1 or prop < 0:
+                raise Exception('Value for "train_prop" must be between 0 and 1, got {}.'.format(prop))
+            if prop == 1:
+                return 'train-img'
+            sample_size = round(prop * len(all_train))
+        
+        random.seed(100)
         sample_images = random.sample(all_train, sample_size)
 
         def _copy_train_chips(img_or_labels):
@@ -185,10 +203,10 @@ class SemanticSegmentationBackend(Backend):
             for s in sample_images:
                 upload_or_copy(join(all_uri, s), join(sample_dir_uri, s))
             return sample_dir
-            
+
         for i in ('labels', 'img'):
             d = _copy_train_chips(i)
-        
+
         return d
 
     def train(self, tmp_dir):
@@ -219,13 +237,8 @@ class SemanticSegmentationBackend(Backend):
         if 0 not in class_map.get_keys():
             classes = ['nodata'] + classes
         num_workers = 0 if self.train_opts.debug else 4
-        
-        if self.train_opts.train_proportion > 1 or self.train_opts.train_proportion < 0:
-            raise Exception('Value for "train_proportion" must be between 0 and 1, got {}.'.format(self.train_opts.train_proportion)) 
-        if self.train_opts.train_proportion == 1:
-            train_img_dir = 'train-img'
-        else:
-            train_img_dir = self.subset_training_data(chip_dir)
+
+        train_img_dir = self.subset_training_data(chip_dir)
 
         data = (SegmentationItemList.from_folder(chip_dir)
                 .split_by_folder(train=train_img_dir, valid='val-img')
@@ -234,7 +247,7 @@ class SemanticSegmentationBackend(Backend):
                 .databunch(bs=self.train_opts.batch_sz,
                            num_workers=num_workers))
         print(data)
-    
+
         if self.train_opts.debug:
             make_debug_chips(data, class_map, tmp_dir, train_uri)
 

--- a/fastai_plugin/semantic_segmentation_backend_config.py
+++ b/fastai_plugin/semantic_segmentation_backend_config.py
@@ -12,11 +12,13 @@ FASTAI_SEMANTIC_SEGMENTATION = 'FASTAI_SEMANTIC_SEGMENTATION'
 
 class TrainOptions():
     def __init__(self, batch_sz=None, weight_decay=None, lr=None,
+                 one_cycle=None,
                  num_epochs=None, model_arch=None, fp16=None,
                  sync_interval=None, debug=None):
         self.batch_sz = batch_sz
         self.weight_decay = weight_decay
         self.lr = lr
+        self.one_cycle = one_cycle
         self.num_epochs = num_epochs
         self.model_arch = model_arch
         self.fp16 = fp16
@@ -46,6 +48,7 @@ class SemanticSegmentationBackendConfigBuilder(SimpleBackendConfigBuilder):
             batch_sz=8,
             weight_decay=1e-2,
             lr=1e-4,
+            one_cycle=False,
             num_epochs=5,
             model_arch='resnet18',
             fp16=False,
@@ -54,6 +57,7 @@ class SemanticSegmentationBackendConfigBuilder(SimpleBackendConfigBuilder):
         b = deepcopy(self)
         b.train_opts = TrainOptions(
             batch_sz=batch_sz, weight_decay=weight_decay, lr=lr,
+            one_cycle=one_cycle,
             num_epochs=num_epochs, model_arch=model_arch, fp16=fp16,
             sync_interval=sync_interval, debug=debug)
         return b

--- a/fastai_plugin/semantic_segmentation_backend_config.py
+++ b/fastai_plugin/semantic_segmentation_backend_config.py
@@ -14,7 +14,7 @@ class TrainOptions():
     def __init__(self, batch_sz=None, weight_decay=None, lr=None,
                  one_cycle=None,
                  num_epochs=None, model_arch=None, fp16=None,
-                 sync_interval=None, debug=None):
+                 sync_interval=None, debug=None, train_proportion=None):
         self.batch_sz = batch_sz
         self.weight_decay = weight_decay
         self.lr = lr
@@ -24,6 +24,7 @@ class TrainOptions():
         self.fp16 = fp16
         self.sync_interval = sync_interval
         self.debug = debug
+        self.train_proportion = train_proportion
 
     def __setattr__(self, name, value):
         if name in ['batch_sz', 'num_epochs', 'sync_interval']:
@@ -53,13 +54,14 @@ class SemanticSegmentationBackendConfigBuilder(SimpleBackendConfigBuilder):
             model_arch='resnet18',
             fp16=False,
             sync_interval=1,
-            debug=False):
+            debug=False,
+            train_proportion=1.0):
         b = deepcopy(self)
         b.train_opts = TrainOptions(
             batch_sz=batch_sz, weight_decay=weight_decay, lr=lr,
             one_cycle=one_cycle,
             num_epochs=num_epochs, model_arch=model_arch, fp16=fp16,
-            sync_interval=sync_interval, debug=debug)
+            sync_interval=sync_interval, debug=debug, train_proportion=train_proportion)
         return b
 
     def with_pretrained_uri(self, pretrained_uri):

--- a/fastai_plugin/semantic_segmentation_backend_config.py
+++ b/fastai_plugin/semantic_segmentation_backend_config.py
@@ -14,7 +14,8 @@ class TrainOptions():
     def __init__(self, batch_sz=None, weight_decay=None, lr=None,
                  one_cycle=None,
                  num_epochs=None, model_arch=None, fp16=None,
-                 sync_interval=None, debug=None, train_proportion=None):
+                 sync_interval=None, debug=None, train_prop=None,
+                 train_count=None):
         self.batch_sz = batch_sz
         self.weight_decay = weight_decay
         self.lr = lr
@@ -24,7 +25,8 @@ class TrainOptions():
         self.fp16 = fp16
         self.sync_interval = sync_interval
         self.debug = debug
-        self.train_proportion = train_proportion
+        self.train_prop = train_prop
+        self.train_count = train_count
 
     def __setattr__(self, name, value):
         if name in ['batch_sz', 'num_epochs', 'sync_interval']:
@@ -55,13 +57,15 @@ class SemanticSegmentationBackendConfigBuilder(SimpleBackendConfigBuilder):
             fp16=False,
             sync_interval=1,
             debug=False,
-            train_proportion=1.0):
+            train_prop=1.0,
+            train_count=None):
         b = deepcopy(self)
         b.train_opts = TrainOptions(
             batch_sz=batch_sz, weight_decay=weight_decay, lr=lr,
             one_cycle=one_cycle,
             num_epochs=num_epochs, model_arch=model_arch, fp16=fp16,
-            sync_interval=sync_interval, debug=debug, train_proportion=train_proportion)
+            sync_interval=sync_interval, debug=debug, train_prop=train_prop,
+            train_count=train_count)
         return b
 
     def with_pretrained_uri(self, pretrained_uri):


### PR DESCRIPTION
This PR adds the option to train a model using only a subset of the available training chips. This should be a value between 0 and 1 and specifies what proportion of the training data to use. It defaults to 1. 

- I used the name `train_proportion`. Don't love it, it's a little long, would be interested in hearing a different idea
- I added an example that uses this parameter to the potsdam examples script. I can take it out but I just left it in there for now for easy testing.
- Should this also have an option to select a number of total chips to use rather than a proportion of the total?

### To Test:

I have tested it locally and remotely on the potsdam dataset

to run a test, adapt the basic fastai semseg example:

```
export RAW_URI="s3://raster-vision-raw-data/isprs-potsdam"
export PROCESSED_URI="s3://raster-vision-lf-dev/fastai/potsdam/processed-data"
export ROOT_URI="{insert root uri}"

rastervision -p fastai run aws_batch -e examples.semantic_segmentation.potsdam -m \
*exp_half_train_data* -a raw_uri $RAW_URI -a processed_uri $PROCESSED_URI\ 
-a root_uri $ROOT_URI -a test False --splits 4
```

closes #12 