### PR TITLE
Add chip classification backend and example experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ var/
 # Jupyter
 .ipynb_checkpoints
 
-./data/
+data/*

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ var/
 .ipynb_checkpoints
 
 data/*
+
+*.zip

--- a/examples/chip_classification/spacenet_rio.py
+++ b/examples/chip_classification/spacenet_rio.py
@@ -23,18 +23,15 @@ class ChipClassificationExperiments(rv.ExperimentSet):
                 debug output
         """
         test = str_to_bool(test)
-        # exp_id = 'spacenet-rio-chip-classification'
-        # num_epochs = 20
-        # batch_size = 16
-        # debug = False
         train_scene_info = get_scene_info(join(processed_uri, 'train-scenes.csv'))
         val_scene_info = get_scene_info(join(processed_uri, 'val-scenes.csv'))
 
+        chip_key = 'spacenet-rio-chip-classification'
         if test:
             exp_id += '-test'
-            num_epochs = 1
-            batch_size = 1
-            debug = True
+            config['num_epochs'] = 1
+            config['batch_sz'] = 2
+            config['debug'] = True
             train_scene_info = train_scene_info[0:1]
             val_scene_info = val_scene_info[0:1]
 
@@ -58,8 +55,7 @@ class ChipClassificationExperiments(rv.ExperimentSet):
             aoi_uri = join(raw_uri, aoi_path)
 
             if test:
-                crop_uri = join(
-                    processed_uri, 'crops', os.path.basename(raster_uri))
+                crop_uri = join(processed_uri, 'crops', os.path.basename(raster_uri))
                 save_image_crop(raster_uri, crop_uri, label_uri=label_uri,
                                 size=600, min_features=20)
                 raster_uri = crop_uri
@@ -92,6 +88,7 @@ class ChipClassificationExperiments(rv.ExperimentSet):
 
         experiment = rv.ExperimentConfig.builder() \
                                         .with_id(exp_id) \
+                                        .with_chip_key(chip_key) \
                                         .with_root_uri(root_uri) \
                                         .with_task(task) \
                                         .with_backend(backend) \
@@ -109,7 +106,8 @@ class ChipClassificationExperiments(rv.ExperimentSet):
             'debug': False,
             'lr': 1e-4,
             'sync_interval': 10,
-            'model_arch': 'resnet18'
+            'model_arch': 'resnet18',
+            'predict_chip_size': 200
         }
         return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri, test)
 

--- a/examples/chip_classification/spacenet_rio.py
+++ b/examples/chip_classification/spacenet_rio.py
@@ -30,10 +30,10 @@ class ChipClassificationExperiments(rv.ExperimentSet):
         if test:
             exp_id += '-test'
             config['num_epochs'] = 1
-            config['batch_sz'] = 32
+            config['batch_sz'] = 8
             config['debug'] = True
-            train_scene_info = train_scene_info[0:4]
-            val_scene_info = val_scene_info[0:4]
+            train_scene_info = train_scene_info[0:1]
+            val_scene_info = val_scene_info[0:1]
 
         task = rv.TaskConfig.builder(rv.CHIP_CLASSIFICATION) \
                             .with_chip_size(200) \
@@ -54,11 +54,10 @@ class ChipClassificationExperiments(rv.ExperimentSet):
             label_uri = join(processed_uri, label_uri)
             aoi_uri = join(raw_uri, aoi_path)
 
-            # if test:
-                # crop_uri = join(processed_uri, 'crops', os.path.basename(raster_uri))
-                # save_image_crop(raster_uri, crop_uri, label_uri=label_uri,
-                #                 size=600, min_features=10)
-                # raster_uri = crop_uri
+            if test:
+                crop_uri = join(processed_uri, 'crops', os.path.basename(raster_uri))
+                save_image_crop(raster_uri, crop_uri, label_uri=label_uri, size=600, min_features=5)
+                raster_uri = crop_uri
 
             id = os.path.splitext(os.path.basename(raster_uri))[0]
             label_source = rv.LabelSourceConfig.builder(rv.CHIP_CLASSIFICATION) \

--- a/examples/chip_classification/spacenet_rio.py
+++ b/examples/chip_classification/spacenet_rio.py
@@ -107,7 +107,18 @@ class ChipClassificationExperiments(rv.ExperimentSet):
             'lr': 1e-4,
             'sync_interval': 10,
             'model_arch': 'resnet18',
-            'predict_chip_size': 200
+        }
+        return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri, test)
+
+    def exp_resnet50(self, raw_uri, processed_uri, root_uri, test=False):
+        exp_id = 'resnet50'
+        config = {
+            'batch_sz': 8,
+            'num_epochs': 5,
+            'debug': False,
+            'lr': 1e-4,
+            'sync_interval': 10,
+            'model_arch': 'resnet50',
         }
         return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri, test)
 

--- a/examples/chip_classification/spacenet_rio.py
+++ b/examples/chip_classification/spacenet_rio.py
@@ -1,0 +1,118 @@
+import os
+from os.path import join
+
+import rastervision as rv
+from examples.utils import get_scene_info, str_to_bool, save_image_crop
+
+from fastai_plugin.chip_classification_backend_config import (
+    FASTAI_CHIP_CLASSIFICATION)
+
+aoi_path = 'AOI_1_Rio/srcData/buildingLabels/Rio_OUTLINE_Public_AOI.geojson'
+
+
+class ChipClassificationExperiments(rv.ExperimentSet):
+    def get_exp(self, exp_id, config, raw_uri, processed_uri, root_uri, test=False):
+        """Chip classification experiment on Spacenet Rio dataset.
+        Run the data prep notebook before running this experiment. Note all URIs can be
+        local or remote.
+        Args:
+            raw_uri: (str) directory of raw data
+            processed_uri: (str) directory of processed data
+            root_uri: (str) root directory for experiment output
+            test: (bool) if True, run a very small experiment as a test and generate
+                debug output
+        """
+        test = str_to_bool(test)
+        # exp_id = 'spacenet-rio-chip-classification'
+        # num_epochs = 20
+        # batch_size = 16
+        # debug = False
+        train_scene_info = get_scene_info(join(processed_uri, 'train-scenes.csv'))
+        val_scene_info = get_scene_info(join(processed_uri, 'val-scenes.csv'))
+
+        if test:
+            exp_id += '-test'
+            num_epochs = 1
+            batch_size = 1
+            debug = True
+            train_scene_info = train_scene_info[0:1]
+            val_scene_info = val_scene_info[0:1]
+
+        task = rv.TaskConfig.builder(rv.CHIP_CLASSIFICATION) \
+                            .with_chip_size(200) \
+                            .with_classes({
+                                'building': (1, 'red'),
+                                'no_building': (2, 'black')
+                            }) \
+                            .build()
+
+        backend = rv.BackendConfig.builder(FASTAI_CHIP_CLASSIFICATION) \
+                                  .with_task(task) \
+                                  .with_train_options(**config) \
+                                  .build()
+
+        def make_scene(scene_info):
+            (raster_uri, label_uri) = scene_info
+            raster_uri = join(raw_uri, raster_uri)
+            label_uri = join(processed_uri, label_uri)
+            aoi_uri = join(raw_uri, aoi_path)
+
+            if test:
+                crop_uri = join(
+                    processed_uri, 'crops', os.path.basename(raster_uri))
+                save_image_crop(raster_uri, crop_uri, label_uri=label_uri,
+                                size=600, min_features=20)
+                raster_uri = crop_uri
+
+            id = os.path.splitext(os.path.basename(raster_uri))[0]
+            label_source = rv.LabelSourceConfig.builder(rv.CHIP_CLASSIFICATION) \
+                                               .with_uri(label_uri) \
+                                               .with_ioa_thresh(0.5) \
+                                               .with_use_intersection_over_cell(False) \
+                                               .with_pick_min_class_id(True) \
+                                               .with_background_class_id(2) \
+                                               .with_infer_cells(True) \
+                                               .build()
+
+            return rv.SceneConfig.builder() \
+                                 .with_task(task) \
+                                 .with_id(id) \
+                                 .with_raster_source(raster_uri) \
+                                 .with_label_source(label_source) \
+                                 .with_aoi_uri(aoi_uri) \
+                                 .build()
+
+        train_scenes = [make_scene(info) for info in train_scene_info]
+        val_scenes = [make_scene(info) for info in val_scene_info]
+
+        dataset = rv.DatasetConfig.builder() \
+                                  .with_train_scenes(train_scenes) \
+                                  .with_validation_scenes(val_scenes) \
+                                  .build()
+
+        experiment = rv.ExperimentConfig.builder() \
+                                        .with_id(exp_id) \
+                                        .with_root_uri(root_uri) \
+                                        .with_task(task) \
+                                        .with_backend(backend) \
+                                        .with_dataset(dataset) \
+                                        .build()
+
+        return experiment
+
+
+    def exp_resnet18(self, raw_uri, processed_uri, root_uri, test=False):
+        exp_id = 'resnet18'
+        config = {
+            'batch_sz': 8,
+            'num_epochs': 5,
+            'debug': False,
+            'lr': 1e-4,
+            'sync_interval': 10,
+            'model_arch': 'resnet18'
+        }
+        return self.get_exp(exp_id, config, raw_uri, processed_uri, root_uri, test)
+
+
+if __name__ == '__main__':
+    rv.main()

--- a/examples/chip_classification/spacenet_rio.py
+++ b/examples/chip_classification/spacenet_rio.py
@@ -30,10 +30,10 @@ class ChipClassificationExperiments(rv.ExperimentSet):
         if test:
             exp_id += '-test'
             config['num_epochs'] = 1
-            config['batch_sz'] = 2
+            config['batch_sz'] = 32
             config['debug'] = True
-            train_scene_info = train_scene_info[0:1]
-            val_scene_info = val_scene_info[0:1]
+            train_scene_info = train_scene_info[0:4]
+            val_scene_info = val_scene_info[0:4]
 
         task = rv.TaskConfig.builder(rv.CHIP_CLASSIFICATION) \
                             .with_chip_size(200) \
@@ -54,11 +54,11 @@ class ChipClassificationExperiments(rv.ExperimentSet):
             label_uri = join(processed_uri, label_uri)
             aoi_uri = join(raw_uri, aoi_path)
 
-            if test:
-                crop_uri = join(processed_uri, 'crops', os.path.basename(raster_uri))
-                save_image_crop(raster_uri, crop_uri, label_uri=label_uri,
-                                size=600, min_features=20)
-                raster_uri = crop_uri
+            # if test:
+                # crop_uri = join(processed_uri, 'crops', os.path.basename(raster_uri))
+                # save_image_crop(raster_uri, crop_uri, label_uri=label_uri,
+                #                 size=600, min_features=10)
+                # raster_uri = crop_uri
 
             id = os.path.splitext(os.path.basename(raster_uri))[0]
             label_source = rv.LabelSourceConfig.builder(rv.CHIP_CLASSIFICATION) \

--- a/fastai_plugin/chip_classification_backend.py
+++ b/fastai_plugin/chip_classification_backend.py
@@ -1,0 +1,412 @@
+import os
+from os.path import join, basename, dirname, isfile
+import uuid
+import zipfile
+import glob
+from pathlib import Path
+import random
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from fastai.vision import (
+    SegmentationItemList, get_transforms, models, unet_learner, Image,
+    ImageSegment)
+from fastai.callbacks import CSVLogger, TrackEpochCallback
+from fastai.basic_train import load_learner
+from fastai.basic_data import DatasetType
+from fastai.vision.transform import dihedral
+from torch.utils.data.sampler import WeightedRandomSampler
+
+from rastervision.utils.files import (
+    get_local_path, make_dir, upload_or_copy, list_paths,
+    download_if_needed, sync_from_dir, sync_to_dir, str_to_file)
+from rastervision.utils.misc import save_img
+from rastervision.backend import Backend
+from rastervision.data.label import SemanticSegmentationLabels
+from rastervision.data.label_source.utils import color_to_triple
+
+from fastai_plugin.utils import (
+    SyncCallback, MySaveModelCallback, ExportCallback, MyCSVLogger,
+    Precision, Recall, FBeta, zipdir)
+
+
+def merge_class_dirs(scene_class_dirs, output_dir):
+    seen_classes = set([])
+    chip_ind = 0
+    for scene_class_dir in scene_class_dirs:
+        for class_name, src_class_dir in scene_class_dir.items():
+            dst_class_dir = join(output_dir, class_name)
+            if class_name not in seen_classes:
+                make_dir(dst_class_dir)
+                seen_classes.add(class_name)
+
+            for src_class_file in [
+                    join(src_class_dir, class_file)
+                    for class_file in os.listdir(src_class_dir)
+            ]:
+                dst_class_file = join(dst_class_dir, '{}.png'.format(chip_ind))
+                shutil.move(src_class_file, dst_class_file)
+                chip_ind += 1
+
+
+class FileGroup(object):
+    def __init__(self, base_uri, tmp_dir):
+        self.tmp_dir = tmp_dir
+        self.base_uri = base_uri
+        self.base_dir = self.get_local_path(base_uri)
+
+        make_dir(self.base_dir)
+
+    def get_local_path(self, uri):
+        return get_local_path(uri, self.tmp_dir)
+
+    def upload_or_copy(self, uri):
+        upload_or_copy(self.get_local_path(uri), uri)
+
+    def download_if_needed(self, uri):
+        return download_if_needed(uri, self.tmp_dir)
+
+
+class DatasetFiles(FileGroup):
+    """Utilities for files produced when calling convert_training_data."""
+
+    def __init__(self, base_uri, tmp_dir):
+        FileGroup.__init__(self, base_uri, tmp_dir)
+
+        self.partition_id = uuid.uuid4()
+
+        self.training_zip_uri = join(base_uri, 'training-{}.zip'.format(self.partition_id))
+        self.training_local_uri = join(self.base_dir, 'training-{}'.format(self.partition_id))
+        self.training_download_uri = self.get_local_path(join(self.base_uri, 'training'))
+        make_dir(self.training_local_uri)
+
+        self.validation_zip_uri = join(base_uri, 'validation-{}.zip'.format(self.partition_id))
+        self.validation_local_uri = join(self.base_dir, 'validation-{}'.format(self.partition_id))
+        self.validation_download_uri = self.get_local_path(join(self.base_uri, 'validation'))
+        make_dir(self.validation_local_uri)
+
+    def download(self):
+        def _download(split, output_dir):
+            scene_class_dirs = []
+            for uri in list_paths(self.base_uri, 'zip'):
+                base_name = os.path.basename(uri)
+                if base_name.startswith(split):
+                    data_zip_path = self.download_if_needed(uri)
+                    data_dir = os.path.splitext(data_zip_path)[0]
+                    shutil.unpack_archive(data_zip_path, data_dir)
+
+                    # Append each of the directories containing this partitions'
+                    # labeled images based on the class directory.
+                    data_dir_subdirectories = next(os.walk(data_dir))[1]
+                    scene_class_dirs.append(
+                        dict([(class_name, os.path.join(data_dir, class_name))
+                              for class_name in data_dir_subdirectories]))
+            merge_class_dirs(scene_class_dirs, output_dir)
+
+        _download('training', self.training_download_uri)
+        _download('validation', self.validation_download_uri)
+
+    def upload(self):
+        def _upload(data_dir, zip_uri, split):
+            if not any(os.scandir(data_dir)):
+                log.warn(
+                    'No data to write for split {} in partition {}...'.format(
+                        split, self.partition_id))
+            else:
+                shutil.make_archive(data_dir, 'zip', data_dir)
+                upload_or_copy(data_dir + '.zip', zip_uri)
+
+        _upload(self.training_local_uri, self.training_zip_uri, 'training')
+        _upload(self.validation_local_uri, self.validation_zip_uri,
+                'validation')
+
+
+class ModelFiles(FileGroup):
+    """Utilities for files produced when calling train."""
+
+    def __init__(self, base_uri, tmp_dir, replace_model=False):
+        """Create these model files.
+
+        Args:
+            base_uri: Base URI of the model files
+            replace_model: If the model file exists, remove.
+                           Used for the training step, to retrain
+                           existing models.
+
+        Returns:
+            A new ModelFile instance.
+        """
+        FileGroup.__init__(self, base_uri, tmp_dir)
+
+        self.model_uri = join(self.base_uri, 'model')
+        self.log_uri = join(self.base_uri, 'log.csv')
+
+        if replace_model:
+            if os.path.exists(self.model_uri):
+                os.remove(self.model_uri)
+            if os.path.exists(self.log_uri):
+                os.remove(self.log_uri)
+
+    def download_backend_config(self, pretrained_model_uri, kc_config,
+                                dataset_files, class_map):
+        from rastervision.protos.keras_classification.pipeline_pb2 \
+            import PipelineConfig
+
+        config = json_format.ParseDict(kc_config, PipelineConfig())
+
+        # Update config using local paths.
+        config.trainer.options.output_dir = self.get_local_path(self.base_uri)
+        config.model.model_path = self.get_local_path(self.model_uri)
+        config.model.nb_classes = len(class_map)
+
+        config.trainer.options.training_data_dir = \
+            dataset_files.training_download_uri
+        config.trainer.options.validation_data_dir = \
+            dataset_files.validation_download_uri
+
+        del config.trainer.options.class_names[:]
+        config.trainer.options.class_names.extend(class_map.get_class_names())
+
+        # Save the pretrained weights locally
+        pretrained_model_path = None
+        if pretrained_model_uri:
+            pretrained_model_path = self.download_if_needed(
+                pretrained_model_uri)
+
+        # Save an updated copy of the config file.
+        config_path = os.path.join(self.tmp_dir, 'kc_config.json')
+        config_str = json_format.MessageToJson(config)
+        with open(config_path, 'w') as config_file:
+            config_file.write(config_str)
+
+        return (config_path, pretrained_model_path)
+
+
+class ChipClassificationBackend(Backend):
+    def __init__(self, task_config, backend_opts, train_opts):
+        self.task_config = task_config
+        self.backend_opts = backend_opts
+        self.train_opts = train_opts
+        self.inf_learner = None
+
+    def print_options(self):
+        # TODO get logging to work for plugins
+        print('Backend options')
+        print('--------------')
+        for k, v in self.backend_opts.__dict__.items():
+            print('{}: {}'.format(k, v))
+        print()
+
+        print('Train options')
+        print('--------------')
+        for k, v in self.train_opts.__dict__.items():
+            print('{}: {}'.format(k, v))
+        print()
+
+    def process_scene_data(self, scene, data, tmp_dir):
+        """Process each scene's training data.
+
+        This writes {scene_id}/img/{scene_id}-{ind}.png and
+        {scene_id}/labels/{scene_id}-{ind}.png
+
+        Args:
+            scene: Scene
+            data: TrainingData
+
+        Returns:
+            backend-specific data-structures consumed by backend's
+            process_sceneset_results
+        """
+
+        scratch_dir = join(tmp_dir, 'scratch-{}'.format(uuid.uuid4()))
+        # Ensure directory is unique since scene id's could be shared between
+        # training and test sets.
+        scene_dir = join(scratch_dir, '{}-{}'.format(scene.id, uuid.uuid4()))
+        class_dirs = {}
+
+        for chip_idx, (chip, window, labels) in enumerate(data):
+            class_id = labels.get_cell_class_id(window)
+            # If a chip is not associated with a class, don't
+            # use it in training data.
+            if class_id is None:
+                continue
+            class_name = self.task_config.class_map.get_by_id(class_id).name
+            class_dir = join(scene_dir, class_name)
+            make_dir(class_dir)
+            class_dirs[class_name] = class_dir
+            chip_name = '{}.png'.format(chip_idx)
+            chip_path = join(class_dir, chip_name)
+            save_img(chip, chip_path)
+
+        return class_dirs
+
+    def process_sceneset_results(self, training_results, validation_results, tmp_dir):
+        """After all scenes have been processed, process the result set.
+
+        This writes a zip file for a group of scenes at {chip_uri}/{uuid}.zip
+        containing:
+        train-img/{scene_id}-{ind}.png
+        train-labels/{scene_id}-{ind}.png
+        val-img/{scene_id}-{ind}.png
+        val-labels/{scene_id}-{ind}.png
+
+        Args:
+            training_results: dependent on the ml_backend's process_scene_data
+            validation_results: dependent on the ml_backend's
+                process_scene_data
+        """
+        self.print_options()
+
+        dataset_files = DatasetFiles(self.backend_opts.chip_uri, tmp_dir)
+        training_dir = dataset_files.training_local_uri
+        validation_dir = dataset_files.validation_local_uri
+
+        merge_class_dirs(training_results, training_dir)
+        merge_class_dirs(validation_results, validation_dir)
+        dataset_files.upload()
+
+
+    def train(self, tmp_dir):
+        """Train a model."""
+        self.print_options()
+
+        # Sync output of previous training run from cloud.
+        train_uri = self.backend_opts.train_uri
+        train_dir = get_local_path(train_uri, tmp_dir)
+        make_dir(train_dir)
+        sync_from_dir(train_uri, train_dir)
+
+        # Get zip file for each group, and unzip them into chip_dir.
+        chip_dir = join(tmp_dir, 'chips')
+        make_dir(chip_dir)
+        for zip_uri in list_paths(self.backend_opts.chip_uri, 'zip'):
+            zip_path = download_if_needed(zip_uri, tmp_dir)
+            with zipfile.ZipFile(zip_path, 'r') as zipf:
+                zipf.extractall(chip_dir)
+
+        # Setup data loader.
+        def get_label_path(im_path):
+            return Path(str(im_path.parent)[:-4] + '-labels') / im_path.name
+
+        size = self.task_config.chip_size
+        class_map = self.task_config.class_map
+        classes = class_map.get_class_names()
+        # if 0 not in class_map.get_keys():
+        #     classes = ['nodata'] + classes
+        num_workers = 0 if self.train_opts.debug else 4
+
+        def get_data(train_sampler=None):
+            data = (ImageList.from_folder(chip_dir)
+                    .split_by_folder(train='training', valid='validation')
+                    .label_from_folder(classes=classes)
+                    .transform(get_transforms(flip_vert=self.train_opts.flip_vert),
+                               size=size, tfm_y=True)
+                    .databunch(bs=self.train_opts.batch_sz,
+                               num_workers=num_workers,
+                               train_sampler=train_sampler))
+            return data
+
+        data = get_data()
+
+        if self.train_opts.debug:
+            make_debug_chips(data, class_map, tmp_dir, train_uri)
+
+        # Setup learner.
+        ignore_idx = -1
+        metrics = [
+            Precision(average='weighted', clas_idx=1, ignore_idx=ignore_idx),
+            Recall(average='weighted', clas_idx=1, ignore_idx=ignore_idx),
+            FBeta(average='weighted', clas_idx=1, beta=1, ignore_idx=ignore_idx)]
+        model_arch = getattr(models, self.train_opts.model_arch)
+        learn = cnn_learner(
+            data, model_arch, metrics=metrics, wd=self.train_opts.weight_decay,
+            path=train_dir)
+        learn.unfreeze()
+
+        if self.train_opts.fp16 and torch.cuda.is_available():
+            # This loss_scale works for Resnet 34 and 50. You might need to adjust this
+            # for other models.
+            learn = learn.to_fp16(loss_scale=256)
+
+        # Setup callbacks and train model.
+        model_path = get_local_path(self.backend_opts.model_uri, tmp_dir)
+
+        pretrained_uri = self.backend_opts.pretrained_uri
+        if pretrained_uri:
+            print('Loading weights from pretrained_uri: {}'.format(
+                pretrained_uri))
+            pretrained_path = download_if_needed(pretrained_uri, tmp_dir)
+            learn.model.load_state_dict(
+                torch.load(pretrained_path, map_location=learn.data.device),
+                strict=False)
+
+        # Save every epoch so that resume functionality provided by
+        # TrackEpochCallback will work.
+        callbacks = [
+            TrackEpochCallback(learn),
+            MySaveModelCallback(learn, every='epoch'),
+            MyCSVLogger(learn, filename='log'),
+            ExportCallback(learn, model_path, monitor='f_beta'),
+            SyncCallback(train_dir, self.backend_opts.train_uri,
+                         self.train_opts.sync_interval)
+        ]
+
+        lr = self.train_opts.lr
+        num_epochs = self.train_opts.num_epochs
+        if self.train_opts.one_cycle:
+            if lr is None:
+                learn.lr_find()
+                learn.recorder.plot(suggestion=True, return_fig=True)
+                lr = learn.recorder.min_grad_lr
+                print('lr_find() found lr: {}'.format(lr))
+            learn.fit_one_cycle(num_epochs, lr, callbacks=callbacks)
+        else:
+            learn.fit(num_epochs, lr, callbacks=callbacks)
+
+        # Since model is exported every epoch, we need some other way to
+        # show that training is finished.
+        str_to_file('done!', self.backend_opts.train_done_uri)
+
+        # Sync output to cloud.
+        sync_to_dir(train_dir, self.backend_opts.train_uri)
+
+    def load_model(self, tmp_dir):
+        """Load the model in preparation for one or more prediction calls."""
+        if self.inf_learner is None:
+            self.print_options()
+            model_uri = self.backend_opts.model_uri
+            model_path = download_if_needed(model_uri, tmp_dir)
+            self.inf_learner = load_learner(
+                dirname(model_path), basename(model_path))
+
+    def predict(self, chips, windows, tmp_dir):
+        """Return predictions for a chip using model.
+
+        Args:
+            chips: [[height, width, channels], ...] numpy array of chips
+            windows: List of boxes that are the windows aligned with the chips.
+
+        Return:
+            Labels object containing predictions
+        """
+        self.load_model(tmp_dir)
+
+        chip = torch.Tensor(chips[0]).permute((2, 0, 1)) / 255.
+        im = Image(chip)
+        self.inf_learner.data.single_ds.tfmargs['size'] = self.task_config.predict_chip_size
+        self.inf_learner.data.single_ds.tfmargs_y['size'] = self.task_config.predict_chip_size
+
+        preds = self.inf_learner.predict(chips)
+
+        labels = ChipClassificationLabels()
+
+        for (_, predicted_class, class_probs), window in zip(preds, windows):
+            # Add 1 to class_id since they start at 1.
+            class_id = int(predicted_class + 1)
+
+            labels.set_cell(window, class_id, class_probs)
+
+        return labels

--- a/fastai_plugin/chip_classification_backend.py
+++ b/fastai_plugin/chip_classification_backend.py
@@ -176,8 +176,11 @@ class ChipClassificationBackend(Backend):
     def process_scene_data(self, scene, data, tmp_dir):
         """Process each scene's training data.
 
-        This writes {scene_id}/img/{scene_id}-{ind}.png and
-        {scene_id}/labels/{scene_id}-{ind}.png
+        This writes 
+        {tmp_dir}/scratch-{uuid}/
+            {scene_id}-{uuid}/
+                {class_name}/
+                    {chip_idx}.png
 
         Args:
             scene: Scene
@@ -213,12 +216,11 @@ class ChipClassificationBackend(Backend):
     def process_sceneset_results(self, training_results, validation_results, tmp_dir):
         """After all scenes have been processed, process the result set.
 
-        This writes a zip file for a group of scenes at {chip_uri}/{uuid}.zip
-        containing:
-        train-img/{scene_id}-{ind}.png
-        train-labels/{scene_id}-{ind}.png
-        val-img/{scene_id}-{ind}.png
-        val-labels/{scene_id}-{ind}.png
+        This writes two zip files:
+            training-{uuid}.zip
+            validation-{uuid}.zip
+        each containing
+            {class_name}/{chip_idx}.png
 
         Args:
             training_results: dependent on the ml_backend's process_scene_data

--- a/fastai_plugin/chip_classification_backend_config.py
+++ b/fastai_plugin/chip_classification_backend_config.py
@@ -1,0 +1,81 @@
+from copy import deepcopy
+
+import rastervision as rv
+
+from fastai_plugin.chip_classification_backend import (
+    ChipClassificationBackend)
+from fastai_plugin.simple_backend_config import (
+    SimpleBackendConfig, SimpleBackendConfigBuilder)
+
+FASTAI_CHIP_CLASSIFICATION = 'FASTAI_CHIP_CLASSIFICATION'
+
+
+class TrainOptions():
+    def __init__(self, batch_sz=None, weight_decay=None, lr=None,
+                 one_cycle=None,
+                 num_epochs=None, model_arch=None, fp16=None,
+                 flip_vert=None, sync_interval=None, debug=None,
+                 train_prop=None, train_count=None, tta=None, oversample=None):
+        self.batch_sz = batch_sz
+        self.weight_decay = weight_decay
+        self.lr = lr
+        self.one_cycle = one_cycle
+        self.num_epochs = num_epochs
+        self.model_arch = model_arch
+        self.fp16 = fp16
+        self.flip_vert = flip_vert
+        self.sync_interval = sync_interval
+        self.debug = debug
+        self.train_prop = train_prop
+        self.train_count = train_count
+        self.tta = tta
+        self.oversample = oversample
+
+    def __setattr__(self, name, value):
+        if name in ['batch_sz', 'num_epochs', 'sync_interval']:
+            value = int(value) if isinstance(value, float) else value
+        super().__setattr__(name, value)
+
+
+class ChipClassificationBackendConfig(SimpleBackendConfig):
+    train_opts_class = TrainOptions
+    backend_type = FASTAI_CHIP_CLASSIFICATION
+    backend_class = ChipClassificationBackend
+
+
+class ChipClassificationBackendConfigBuilder(SimpleBackendConfigBuilder):
+    config_class = ChipClassificationBackendConfig
+
+    def _applicable_tasks(self):
+        return [rv.CHIP_CLASSIFICATION]
+
+    def with_train_options(
+            self,
+            batch_sz=8,
+            weight_decay=1e-2,
+            lr=1e-4,
+            one_cycle=False,
+            num_epochs=1,
+            model_arch='resnet18',
+            fp16=False,
+            flip_vert=False,
+            sync_interval=1,
+            debug=False):
+
+        b = deepcopy(self)
+        b.train_opts = TrainOptions(
+            batch_sz=batch_sz, weight_decay=weight_decay, lr=lr,
+            one_cycle=one_cycle,
+            num_epochs=num_epochs, model_arch=model_arch, fp16=fp16,
+            flip_vert=flip_vert, sync_interval=sync_interval, debug=debug)
+        return b
+
+    def with_pretrained_uri(self, pretrained_uri):
+        """pretrained_uri should be uri of exported model file."""
+        return super().with_pretrained_uri(pretrained_uri)
+
+
+def register_plugin(plugin_registry):
+    plugin_registry.register_config_builder(
+        rv.BACKEND, FASTAI_CHIP_CLASSIFICATION,
+        ChipClassificationBackendConfigBuilder)

--- a/fastai_plugin/chip_classification_backend_config.py
+++ b/fastai_plugin/chip_classification_backend_config.py
@@ -15,7 +15,7 @@ class TrainOptions():
                  one_cycle=None,
                  num_epochs=None, model_arch=None, fp16=None,
                  flip_vert=None, sync_interval=None, debug=None,
-                 train_prop=None, train_count=None, tta=None, oversample=None):
+                 train_prop=None, train_count=None, tta=None, oversample=None, predict_chip_size=200):
         self.batch_sz = batch_sz
         self.weight_decay = weight_decay
         self.lr = lr
@@ -26,10 +26,7 @@ class TrainOptions():
         self.flip_vert = flip_vert
         self.sync_interval = sync_interval
         self.debug = debug
-        self.train_prop = train_prop
-        self.train_count = train_count
-        self.tta = tta
-        self.oversample = oversample
+        self.predict_chip_size = predict_chip_size
 
     def __setattr__(self, name, value):
         if name in ['batch_sz', 'num_epochs', 'sync_interval']:
@@ -60,14 +57,16 @@ class ChipClassificationBackendConfigBuilder(SimpleBackendConfigBuilder):
             fp16=False,
             flip_vert=False,
             sync_interval=1,
-            debug=False):
+            debug=False,
+            predict_chip_size=200):
 
         b = deepcopy(self)
         b.train_opts = TrainOptions(
             batch_sz=batch_sz, weight_decay=weight_decay, lr=lr,
             one_cycle=one_cycle,
             num_epochs=num_epochs, model_arch=model_arch, fp16=fp16,
-            flip_vert=flip_vert, sync_interval=sync_interval, debug=debug)
+            flip_vert=flip_vert, sync_interval=sync_interval, debug=debug,
+            predict_chip_size=predict_chip_size)
         return b
 
     def with_pretrained_uri(self, pretrained_uri):

--- a/fastai_plugin/chip_classification_backend_config.py
+++ b/fastai_plugin/chip_classification_backend_config.py
@@ -15,7 +15,7 @@ class TrainOptions():
                  one_cycle=None,
                  num_epochs=None, model_arch=None, fp16=None,
                  flip_vert=None, sync_interval=None, debug=None,
-                 train_prop=None, train_count=None, tta=None, oversample=None, predict_chip_size=200):
+                 train_prop=None, train_count=None, tta=None, oversample=None):
         self.batch_sz = batch_sz
         self.weight_decay = weight_decay
         self.lr = lr
@@ -26,7 +26,6 @@ class TrainOptions():
         self.flip_vert = flip_vert
         self.sync_interval = sync_interval
         self.debug = debug
-        self.predict_chip_size = predict_chip_size
 
     def __setattr__(self, name, value):
         if name in ['batch_sz', 'num_epochs', 'sync_interval']:
@@ -57,16 +56,14 @@ class ChipClassificationBackendConfigBuilder(SimpleBackendConfigBuilder):
             fp16=False,
             flip_vert=False,
             sync_interval=1,
-            debug=False,
-            predict_chip_size=200):
+            debug=False):
 
         b = deepcopy(self)
         b.train_opts = TrainOptions(
             batch_sz=batch_sz, weight_decay=weight_decay, lr=lr,
             one_cycle=one_cycle,
             num_epochs=num_epochs, model_arch=model_arch, fp16=fp16,
-            flip_vert=flip_vert, sync_interval=sync_interval, debug=debug,
-            predict_chip_size=predict_chip_size)
+            flip_vert=flip_vert, sync_interval=sync_interval, debug=debug)
         return b
 
     def with_pretrained_uri(self, pretrained_uri):


### PR DESCRIPTION
The output of the full experiment run are available at: https://s3.console.aws.amazon.com/s3/buckets/raster-vision-ahassan/fastai/spacenet/rio/remote-output/?region=us-east-1

The eval metrics are about the same as for the Keras backend:
```{JSON}
[
    {
        "precision": 0.9610891701370387,
        "recall": 0.9739904175222451,
        "f1": 0.9671508020220596,
        "count_error": 0.0,
        "gt_count": 1461.0,
        "class_id": 1,
        "class_name": "building"
    },
    {
        "precision": 0.9834804892287192,
        "recall": 0.9740596627756162,
        "f1": 0.9787069337794698,
        "count_error": 0.0,
        "gt_count": 2313.0,
        "class_id": 2,
        "class_name": "no_building"
    },
    {
        "precision": 0.9748123076725599,
        "recall": 0.9740328563857976,
        "f1": 0.9742332961277538,
        "count_error": 0.0,
        "gt_count": 3774.0,
        "class_id": null,
        "class_name": "average"
    }
]
```